### PR TITLE
Handle observer cleanup more aggressively to catch leak

### DIFF
--- a/proxymw/middleware_test.go
+++ b/proxymw/middleware_test.go
@@ -36,6 +36,7 @@ func TestMiddlewareOrder(t *testing.T) {
 		JitterDelay:  time.Second,
 
 		EnableObserver: true,
+		ClientTimeout:  time.Hour,
 	}
 
 	serveCalls := 0

--- a/proxymw/mock.go
+++ b/proxymw/mock.go
@@ -11,11 +11,13 @@ type Mocker struct {
 	RoundTripFunc func(r *http.Request) (*http.Response, error)
 	InitFunc      func(context.Context)
 	NextFunc      func(Request) error
+	RequestFunc   func() *http.Request
 }
 
 var _ http.Handler = &Mocker{}
 var _ http.RoundTripper = &Mocker{}
 var _ ProxyClient = &Mocker{}
+var _ Request = &Mocker{}
 
 func (m *Mocker) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	m.ServeHTTPFunc(w, r)
@@ -31,4 +33,8 @@ func (m *Mocker) Init(ctx context.Context) {
 
 func (m *Mocker) Next(rr Request) error {
 	return m.NextFunc(rr)
+}
+
+func (m *Mocker) Request() *http.Request {
+	return m.RequestFunc()
 }


### PR DESCRIPTION
catches a bug where concurrent queries does not decrement and simply shows an increasing count of concurrently active requests. this metric is important for operators to tune the backpressure watermark correctly